### PR TITLE
Fix tokenizer instructions

### DIFF
--- a/documentation/tokenizer.html
+++ b/documentation/tokenizer.html
@@ -115,7 +115,7 @@ command: by its name. Once installed the gem normally sits in your path so you c
 
 <p>Tokenizing some text:</p>
 
-<pre><code>echo "This is English text" | tokenizer -l en --no-kaf
+<pre><code>echo "This is English text" | tokenizer -l en -p
 </code></pre>
 
 <p>Will result in</p>

--- a/documentation/tokenizer.html
+++ b/documentation/tokenizer.html
@@ -102,7 +102,7 @@
 
 <p>Installing the tokenizer can be done by executing:</p>
 
-<pre><code>gem install tokenizer
+<pre><code>gem install opener-tokenizer
 </code></pre>
 
 <p>Please bare in mind that all components in OpeNER take KAF as an input and


### PR DESCRIPTION
Hey, just running through your installation instructions.  It specifies installing the `tokenizer` gem which also does tokenization, but is obviously is quite different from `opener-tokenizer`.

Additionally the sample command is incorrect and the `--no-kaf` argument appears to have been replaced with `-p`